### PR TITLE
switch from parity-codec to parity-scale-codec create (v1.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,11 +14,21 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitvec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cennznut"
 version = "0.1.1"
 dependencies = [
  "bit_reverse 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -27,11 +37,13 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "parity-codec"
-version = "3.5.1"
+name = "parity-scale-codec"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -43,6 +55,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum bit_reverse 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5e97e02db5a2899c0377f3d6031d5da8296ca2b47abef6ed699de51b9e40a28c"
+"checksum bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9633b74910e1870f50f5af189b08487195cdb83c0e27a71d6f64d5e09dd0538b"
+"checksum byte-slice-cast 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7cbcbf18128ec71d8d4a0d054461ec59fff5b75b7d10a4c9b7c7cb1a379c3e77"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
-"checksum parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dcb43c05fb71c03b4ea7327bf15694da1e0f23f19d5b1e95bab6c6d74097e336"
+"checksum parity-scale-codec 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "65582b5c02128a4b0fa60fb3e070216e9c84be3e4a8f1b74bc37e15a25e58daf"
 "checksum serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)" = "960e29cf7004b3b6e65fc5002981400eb3ccc017a08a2406940823e58e7179a9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Centrality Developers <developers@centrality.ai>"]
 edition = "2018"
 
 [dependencies]
-parity-codec = { version = "3.5.1", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.0.0" }
 bit_reverse = { version = "0.1.7", default-features = false }
 
 [features]
 default = [ "std" ]
 std = [
-  "parity-codec/std"
+  "codec/std"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl Decode for CENNZnutV0 {
             input.read_byte()?.swap_bits(),
         ]);
         if version != 0 {
-            () //TODO: what type of error to return
+            return Err(codec::Error::from("expected version : 0"));
         }
 
         let module_count = (input.read_byte()?.swap_bits()) + 1;

--- a/src/test.rs
+++ b/src/test.rs
@@ -181,6 +181,18 @@ fn it_works_decode_with_method_cooldown() {
 }
 
 #[test]
+#[should_panic(expected = "expected version : 0")]
+fn it_works_decode_with_version_0() {
+    let encoded: Vec<u8> = vec![
+        1, 2, 3, 192, 109, 111, 100, 117, 108, 101, 95, 116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 138, 128, 0, 128, 109, 101, 116, 104, 111, 100,
+        95, 116, 101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 222,
+        0, 0, 0,
+    ];
+    CENNZnutV0::decode(&mut &encoded[..]).unwrap();
+}
+
+#[test]
 fn it_works_with_lots_of_things_codec() {
     let method = Method {
         name: "method_test".to_string(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{CENNZnutV0, Method, Module};
-use parity_codec::{Decode, Encode};
+use codec::{Decode, Encode};
 use std::string::{String, ToString};
 use std::vec::Vec;
 


### PR DESCRIPTION
- `decode()` return type changes from Option<T> to Result<T, E>
- test added for violating version 0 match

closes #4 