### PR TITLE
improve tests for constraints

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -39,7 +39,7 @@ fn it_works_encode() {
             101, 115, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         ]
     );
-    assert_eq!(encoded[2], 0); // 1 module encoded as 0
+    assert_eq!(encoded[2], 0); // 1 module encodes to 0
 }
 
 #[test]


### PR DESCRIPTION
- add assert for 1 module encoded as 0 (it_works_decode() already has the counterpart test)
- add assert to check if constraints length is encoded as length - 1
- add assert to check if constraints are decoded as constraints_length + 1
- multiple assert_eq! macros within a test will panic at first error
  (we can rely on this to ensure all assertions are passed through to pass a test)