### PR TITLE
More concise to loop over references to containers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl Encode for Method {
         };
         buf.push_byte(has_cooldown_byte | has_constraints_byte);
 
-        let mut name = [0u8; 32];
+        let mut name = [0_u8; 32];
         for i in 0..self.name.len() {
             name[i] = self.name.as_bytes()[i];
         }
@@ -104,7 +104,7 @@ impl Encode for Module {
             method_count_and_has_cooldown_byte |= 0b0000_0001;
         }
         buf.push_byte(method_count_and_has_cooldown_byte.swap_bits());
-        let mut name = [0u8; 32];
+        let mut name = [0_u8; 32];
         for i in 0..self.name.len() {
             name[i] = self.name.as_bytes()[i];
         }
@@ -147,7 +147,7 @@ impl Encode for CENNZnutV0 {
         let module_count = ((self.modules.len() as u8) - 1).swap_bits();
         buf.push_byte(module_count);
 
-        for (_, module) in self.modules.iter() {
+        for (_, module) in &self.modules {
             module.encode_to(buf);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct Module {
 impl Module {
     /// Returns the method, if it exists in the Module
     pub fn get_method(&self, method: &str) -> Option<&Method> {
-        for (name, m) in self.methods.iter() {
+        for (name, m) in &self.methods {
             if name == method {
                 return Some(m);
             }
@@ -116,7 +116,7 @@ impl Encode for Module {
             }
         }
 
-        for (_, method) in self.methods.iter() {
+        for (_, method) in &self.methods {
             method.encode_to(buf);
         }
     }
@@ -131,7 +131,7 @@ pub struct CENNZnutV0 {
 impl CENNZnutV0 {
     /// Returns the module, if it exists in the CENNZnut
     pub fn get_module(&self, module: &str) -> Option<&Module> {
-        for (name, m) in self.modules.iter() {
+        for (name, m) in &self.modules {
             if name == module {
                 return Some(m);
             }


### PR DESCRIPTION
it is more concise to loop over references to containers instead of using explicit iteration methods