### PR TITLE
Feature/28 wildcards

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub enum Domain {
     Module,
 }
 
+const WILDCARD: &str = "*";
+
 impl Display for Domain {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -172,7 +174,7 @@ impl Module {
             if name == method {
                 outcome = Some(m);
                 break;
-            } else if name == "*" {
+            } else if name == WILDCARD {
                 outcome = Some(m);
             }
         }
@@ -213,14 +215,14 @@ pub struct CENNZnutV0 {
 
 impl CENNZnutV0 {
     /// Returns the module, if it exists in the CENNZnut
+    /// Wildcard modules have lower priority than defined modules
     pub fn get_module(&self, module: &str) -> Option<&Module> {
         let mut outcome: Option<&Module> = None;
         for (name, m) in &self.modules {
             if name == module {
                 outcome = Some(m);
                 break;
-            }
-            if name == "*" {
+            } else if name == WILDCARD {
                 outcome = Some(m);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@ pub struct Module {
     pub name: String,
     pub block_cooldown: Option<u32>,
     pub methods: Vec<(String, Method)>,
-    wild_method: Method,
 }
 
 impl Module {
@@ -152,7 +151,6 @@ impl Module {
             name: name.to_string(),
             block_cooldown: None,
             methods: Vec::new(),
-            wild_method: Method::new("wild"),
         }
     }
 
@@ -168,11 +166,8 @@ impl Module {
 
     /// Returns the method, if it exists in the Module
     pub fn get_method(&self, method: &str) -> Option<&Method> {
-        if self.methods.len() == 0 {
-            return Some(&self.wild_method);
-        }
         for (name, m) in &self.methods {
-            if name == method {
+            if name == method || name == "*" {
                 return Some(m);
             }
         }
@@ -322,7 +317,6 @@ impl Decode for Module {
             name,
             block_cooldown: module_cooldown,
             methods,
-            wild_method: Method::new("wild"),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ impl CENNZnutV0 {
     /// Returns the module, if it exists in the CENNZnut
     pub fn get_module(&self, module: &str) -> Option<&Module> {
         for (name, m) in &self.modules {
-            if name == module {
+            if name == module || name == "*" {
                 return Some(m);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// Copyright 2019 Centrality Investments Limited
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::pedantic)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ pub struct Module {
     pub name: String,
     pub block_cooldown: Option<u32>,
     pub methods: Vec<(String, Method)>,
+    wild_method: Method,
 }
 
 impl Module {
@@ -149,6 +150,7 @@ impl Module {
             name: name.to_string(),
             block_cooldown: None,
             methods: Vec::new(),
+            wild_method: Method::new("wild"),
         }
     }
 
@@ -164,6 +166,9 @@ impl Module {
 
     /// Returns the method, if it exists in the Module
     pub fn get_method(&self, method: &str) -> Option<&Method> {
+        if self.methods.len() == 0 {
+            return Some(&self.wild_method);
+        }
         for (name, m) in &self.methods {
             if name == method {
                 return Some(m);
@@ -315,6 +320,7 @@ impl Decode for Module {
             name,
             block_cooldown: module_cooldown,
             methods,
+            wild_method: Method::new("wild"),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub enum Domain {
     Module,
 }
 
-const WILDCARD: &str = "*";
+pub const WILDCARD: &str = "*";
 
 impl Display for Domain {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,13 +165,18 @@ impl Module {
     }
 
     /// Returns the method, if it exists in the Module
+    /// Wildcard methods have lower priority than defined methods
     pub fn get_method(&self, method: &str) -> Option<&Method> {
+        let mut outcome: Option<&Method> = None;
         for (name, m) in &self.methods {
-            if name == method || name == "*" {
-                return Some(m);
+            if name == method {
+                outcome = Some(m);
+                break;
+            } else if name == "*" {
+                outcome = Some(m);
             }
         }
-        None
+        outcome
     }
 }
 
@@ -209,12 +214,17 @@ pub struct CENNZnutV0 {
 impl CENNZnutV0 {
     /// Returns the module, if it exists in the CENNZnut
     pub fn get_module(&self, module: &str) -> Option<&Module> {
+        let mut outcome: Option<&Module> = None;
         for (name, m) in &self.modules {
-            if name == module || name == "*" {
-                return Some(m);
+            if name == module {
+                outcome = Some(m);
+                break;
+            }
+            if name == "*" {
+                outcome = Some(m);
             }
         }
-        None
+        outcome
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -602,3 +602,44 @@ fn unregistered_method_fails_validation() {
         Ok(())
     );
 }
+
+#[test]
+fn registered_methods_have_priority_over_wildcard_methods() {
+    let wild_method = Method::new("*").block_cooldown(123);
+    let registered_method = Method::new("registered_method").block_cooldown(123);
+
+    let mut methods: Vec<(String, Method)> = Vec::default();
+    methods.push((wild_method.name.clone(), wild_method.clone()));
+    methods.push((registered_method.name.clone(), registered_method.clone()));
+
+    let module = Module::new("module_test")
+        .block_cooldown(1)
+        .methods(methods);
+
+    let result = module.get_method("registered_method").unwrap();
+
+    assert_eq!(result.name, "registered_method");
+}
+
+#[test]
+fn registered_modules_have_priority_over_wildcard_modules() {
+    let method = Method::new("registered_method").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let wild_module = Module::new("*")
+        .block_cooldown(123)
+        .methods(methods.clone());
+    let registered_module = Module::new("registered_module")
+        .block_cooldown(123)
+        .methods(methods);
+
+    let mut modules: Vec<(String, Module)> = Vec::default();
+    modules.push((wild_module.name.clone(), wild_module.clone()));
+    modules.push((registered_module.name.clone(), registered_module.clone()));
+
+    let cennznut = CENNZnutV0 { modules };
+
+    let result = cennznut.get_module("registered_module").unwrap();
+
+    assert_eq!(result.name, "registered_module");
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -495,7 +495,7 @@ fn wildcard_method() {
         .methods(methods);
 
     let result = module.get_method("my_unregistered_method");
-    assert_ne!(result.name, None);
+    assert_ne!(result, None);
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@
 #![warn(clippy::pedantic)]
 #![cfg(test)]
 
-use crate::{CENNZnutV0, Domain, Method, Module, Validate, ValidationErr};
+use crate::{CENNZnutV0, Domain, Method, Module, Validate, ValidationErr, WILDCARD};
 use bit_reverse::ParallelReverse;
 use codec::{Decode, Encode};
 use pact::compiler::{Contract, DataTable};
@@ -487,7 +487,7 @@ fn it_works_get_pact() {
 
 #[test]
 fn wildcard_method() {
-    let method = Method::new("*").block_cooldown(123);
+    let method = Method::new(WILDCARD).block_cooldown(123);
     let methods = make_methods(&method);
 
     let module = Module::new("module_test")
@@ -500,7 +500,7 @@ fn wildcard_method() {
 
 #[test]
 fn wildcard_method_validates() {
-    let method = Method::new("*").block_cooldown(123);
+    let method = Method::new(WILDCARD).block_cooldown(123);
     let methods = make_methods(&method);
 
     let module = Module::new("module_test")
@@ -522,7 +522,7 @@ fn wildcard_module() {
     let method = Method::new("registered_method").block_cooldown(123);
     let methods = make_methods(&method);
 
-    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let module = Module::new(WILDCARD).block_cooldown(1).methods(methods);
     let modules = make_modules(&module);
 
     let cennznut = CENNZnutV0 { modules };
@@ -536,7 +536,7 @@ fn wildcard_module_validates() {
     let method = Method::new("registered_method").block_cooldown(123);
     let methods = make_methods(&method);
 
-    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let module = Module::new(WILDCARD).block_cooldown(1).methods(methods);
     let modules = make_modules(&module);
 
     let cennznut = CENNZnutV0 { modules };
@@ -550,10 +550,10 @@ fn wildcard_module_validates() {
 
 #[test]
 fn wildcard_module_wildcard_method_validates() {
-    let method = Method::new("*").block_cooldown(123);
+    let method = Method::new(WILDCARD).block_cooldown(123);
     let methods = make_methods(&method);
 
-    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let module = Module::new(WILDCARD).block_cooldown(1).methods(methods);
     let modules = make_modules(&module);
 
     let cennznut = CENNZnutV0 { modules };
@@ -605,7 +605,7 @@ fn unregistered_method_fails_validation() {
 
 #[test]
 fn registered_methods_have_priority_over_wildcard_methods() {
-    let wild_method = Method::new("*").block_cooldown(123);
+    let wild_method = Method::new(WILDCARD).block_cooldown(123);
     let registered_method = Method::new("registered_method").block_cooldown(123);
 
     let mut methods: Vec<(String, Method)> = Vec::default();
@@ -626,7 +626,7 @@ fn registered_modules_have_priority_over_wildcard_modules() {
     let method = Method::new("registered_method").block_cooldown(123);
     let methods = make_methods(&method);
 
-    let wild_module = Module::new("*")
+    let wild_module = Module::new(WILDCARD)
         .block_cooldown(123)
         .methods(methods.clone());
     let registered_module = Module::new("registered_module")

--- a/src/test.rs
+++ b/src/test.rs
@@ -512,5 +512,8 @@ fn wildcard_method_validates() {
         PactType::StringLike(StringLike(b"test")),
     ];
 
-    assert_eq!(cennznut.validate(&module.name, "my_unregistered_method", &args), Ok(()));
+    assert_eq!(
+        cennznut.validate(&module.name, "my_unregistered_method", &args),
+        Ok(())
+    );
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -487,7 +487,8 @@ fn it_works_get_pact() {
 
 #[test]
 fn wildcard_method() {
-    let methods: Vec<(String, Method)> = Vec::default();
+    let method = Method::new("*").block_cooldown(123);
+    let methods = make_methods(&method);
 
     let module = Module::new("module_test")
         .block_cooldown(1)
@@ -499,7 +500,8 @@ fn wildcard_method() {
 
 #[test]
 fn wildcard_method_validates() {
-    let methods: Vec<(String, Method)> = Vec::default();
+    let method = Method::new("*").block_cooldown(123);
+    let methods = make_methods(&method);
 
     let module = Module::new("module_test")
         .block_cooldown(1)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,5 @@
+// Copyright 2019 Centrality Investments Limited
+
 #![warn(clippy::pedantic)]
 #![cfg(test)]
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -495,7 +495,7 @@ fn wildcard_method() {
         .methods(methods);
 
     let result = module.get_method("my_unregistered_method");
-    assert_ne!(result, None);
+    assert_ne!(result.name, None);
 }
 
 #[test]
@@ -578,9 +578,9 @@ fn unregistered_module_fails_validation() {
     let cennznut = CENNZnutV0 { modules };
     let args = [];
 
-    assert_ne!(
+    assert_eq!(
         cennznut.validate("my_unregistered_module", "registered_method", &args),
-        Ok(())
+        Err(ValidationErr::NoPermission(Domain::Module))
     );
 }
 
@@ -597,9 +597,9 @@ fn unregistered_method_fails_validation() {
     let cennznut = CENNZnutV0 { modules };
     let args = [];
 
-    assert_ne!(
+    assert_eq!(
         cennznut.validate("registered_module", "my_unregistered_method", &args),
-        Ok(())
+        Err(ValidationErr::NoPermission(Domain::Method))
     );
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -482,3 +482,33 @@ fn it_works_get_pact() {
 
     assert_eq!(contract_without, None);
 }
+
+#[test]
+fn wildcard_method() {
+    let methods: Vec<(String, Method)> = Vec::default();
+
+    let module = Module::new("module_test")
+        .block_cooldown(1)
+        .methods(methods);
+
+    let result = module.get_method("my_unregistered_method");
+    assert_ne!(result, None);
+}
+
+#[test]
+fn wildcard_method_validates() {
+    let methods: Vec<(String, Method)> = Vec::default();
+
+    let module = Module::new("module_test")
+        .block_cooldown(1)
+        .methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+    let args = [
+        PactType::Numeric(Numeric(0)),
+        PactType::StringLike(StringLike(b"test")),
+    ];
+
+    assert_eq!(cennznut.validate(&module.name, "my_unregistered_method", &args), Ok(()));
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -509,13 +509,96 @@ fn wildcard_method_validates() {
     let modules = make_modules(&module);
 
     let cennznut = CENNZnutV0 { modules };
-    let args = [
-        PactType::Numeric(Numeric(0)),
-        PactType::StringLike(StringLike(b"test")),
-    ];
+    let args = [];
 
     assert_eq!(
         cennznut.validate(&module.name, "my_unregistered_method", &args),
+        Ok(())
+    );
+}
+
+#[test]
+fn wildcard_module() {
+    let method = Method::new("registered_method").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+
+    let result = cennznut.get_module("my_unregistered_module");
+    assert_ne!(result, None);
+}
+
+#[test]
+fn wildcard_module_validates() {
+    let method = Method::new("registered_method").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+    let args = [];
+
+    assert_eq!(
+        cennznut.validate("my_unregistered_module", "registered_method", &args),
+        Ok(())
+    );
+}
+
+#[test]
+fn wildcard_module_wildcard_method_validates() {
+    let method = Method::new("*").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let module = Module::new("*").block_cooldown(1).methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+    let args = [];
+
+    assert_eq!(
+        cennznut.validate("my_unregistered_module", "my_unregistered_method", &args),
+        Ok(())
+    );
+}
+
+#[test]
+fn unregistered_module_fails_validation() {
+    let method = Method::new("registered_method").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let module = Module::new("registered_module")
+        .block_cooldown(1)
+        .methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+    let args = [];
+
+    assert_ne!(
+        cennznut.validate("my_unregistered_module", "registered_method", &args),
+        Ok(())
+    );
+}
+
+#[test]
+fn unregistered_method_fails_validation() {
+    let method = Method::new("registered_method").block_cooldown(123);
+    let methods = make_methods(&method);
+
+    let module = Module::new("registered_module")
+        .block_cooldown(1)
+        .methods(methods);
+    let modules = make_modules(&module);
+
+    let cennznut = CENNZnutV0 { modules };
+    let args = [];
+
+    assert_ne!(
+        cennznut.validate("registered_module", "my_unregistered_method", &args),
         Ok(())
     );
 }


### PR DESCRIPTION
Add wildcard option to modules and methods.

- Wildcard methods are defined as methods named "*"
- Wildcard modules are defined as modules named "*"
- Wildcard methods allow any unlisted method in its respective module to be used under the wildcard method's constraints
- Wildcard modules allow any unlisted module in its respective cennznut to be used under the wildcard module's constraints
- Defined methods and modules always take precedence over wildcard implementations
- Related documentation updates: https://github.com/cennznet/doughnut-paper/pull/3
 
Closes #28 #29 #20