### PR TITLE
Cennznet integration updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ pub use core::convert::TryFrom;
 mod cennznut;
 mod validation;
 
+pub use crate::cennznut::RuntimeDomain;
+pub use crate::cennznut::ContractDomain;
+
 pub use crate::cennznut::v0::CENNZnutV0;
 pub use crate::cennznut::CENNZnut;
 pub use crate::validation::ValidationErr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,10 @@ pub use core::convert::TryFrom;
 mod cennznut;
 mod validation;
 
-pub use crate::cennznut::RuntimeDomain;
 pub use crate::cennznut::ContractDomain;
+pub use crate::cennznut::RuntimeDomain;
+
+pub use crate::cennznut::v0;
 
 pub use crate::cennznut::v0::CENNZnutV0;
 pub use crate::cennznut::CENNZnut;


### PR DESCRIPTION
This PR is required by https://github.com/cennznet/cennznet/pull/187
It exposes the required interface to integrate into CENNZnet

## Changes:

- Expose required interfaces for integration and testing in CENNZnet

## Concerns:

- None