### PR TITLE
Prevent buffer overflow with a hard cap on encode size

### DIFF
--- a/src/cennznut/v0/mod.rs
+++ b/src/cennznut/v0/mod.rs
@@ -31,7 +31,7 @@ pub const MAX_MODULES: usize = 256;
 pub const MAX_METHODS: usize = 128;
 pub const MAX_CONTRACTS: usize = 255;
 pub const VERSION_BYTES: [u8; 2] = [0, 0];
-pub const MAX_CENNZNUT_BYTES: usize = 0xffff;
+pub const MAX_CENNZNUT_BYTES: usize = u16::max_value() as usize;
 
 /// A CENNZnet permission domain struct for embedding in doughnuts
 #[cfg_attr(test, derive(Clone, Debug, Eq, PartialEq))]
@@ -95,7 +95,7 @@ impl Encode for CENNZnutV0 {
             module_payload_buf.write(module_buf.as_slice());
         }
 
-        let mut preliminary_buf: Vec<u8> = Vec::<u8>::default();
+        let mut preliminary_buf = Vec::<u8>::default();
 
         preliminary_buf.write(&VERSION_BYTES);
 

--- a/src/cennznut/v0/tests.rs
+++ b/src/cennznut/v0/tests.rs
@@ -935,3 +935,22 @@ fn it_fails_to_encode_with_too_many_contracts() {
     let cennznut = CENNZnutV0 { modules, contracts };
     assert_eq!(cennznut.encode(), []);
 }
+
+#[test]
+fn it_fails_to_encode_when_cennznut_is_too_large() {
+    // 33 bytes per method, 33 + 33 * Method bytes per module
+    // if 64 methods, per 64 modules, total bytes > 137,000
+    let mut methods: Vec<(MethodName, Method)> = Vec::default();
+    let mut modules: Vec<(ModuleName, Module)> = Vec::default();
+    for x in 0..64 + 1 {
+        let method = Method::new(&x.to_string());
+        methods.push((method.name.clone(), method));
+    }
+    for x in 0..64 + 1 {
+        let module = Module::new(&x.to_string()).methods(methods.clone());
+        modules.push((module.name.clone(), module));
+    }
+    let contracts = Vec::<(ContractAddress, Contract)>::default();
+    let cennznut = CENNZnutV0 { modules, contracts };
+    assert_eq!(cennznut.encode(), []);
+}


### PR DESCRIPTION
A potential buffer overflow can occur in CENNZnuts. This is because without protection (provided by this PR), the maximum size of an encoded CENNZnut is 9,540,063 bytes. However a doughnut will only allocate 65535 bytes for an encoded CENNZnut permission domain.

## Changes

* Apply a hard limit of 65535 bytes when encoding CENNZnut
* If this limit is exceeded, the entire encoding is discarded to ensure we do not provide a corrupted CENNZnut

## Concerns

* encoding does not provide a means to return Errors, so in this case I have chosen to just return empty