### PR TITLE
Fix browser build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,16 @@ commands:
       - run:
           name: Js install + Build
           command: |
-            # install npm + yarn + wasm-pack
-            sudo apt install npm
+            # install
+            # node
+            curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+            sudo apt-get install -y nodejs
+            # yarn
             curl -o- -L https://yarnpkg.com/install.sh | bash
             export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
+            # wasm-pack
             curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-            # build
+            # buidl
             cd js && yarn build
   test-js:
     steps:
@@ -66,9 +70,6 @@ jobs:
           command: |
             echo "//registry.npmjs.org/:_authToken=${NPM_KEY}" > ~/.npmrc
             cd js
-            # node vs npm versions are funny
-            npm uninstall -g npm
-            npm pack
             npm publish --access public --tag next
   test:
     docker:

--- a/js/build.sh
+++ b/js/build.sh
@@ -1,4 +1,5 @@
-# compile the rust codebase
+#!/bin/bash
+set -ex
 echo "building js pkg for $1 out to: $2"
 wasm-pack build \
     --target $1 \
@@ -9,5 +10,5 @@ wasm-pack build \
 
 # Remove wasm-pack generated files
 # They are unintentionally excluding required files when `npm pack` is run
-rm -rf $2/{package.json,README.md,.gitignore,LICENSE}
-
+cd $2
+rm package.json README.md .gitignore LICENSE

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cennznet/cennznut-wasm",
-  "version": "0.0.1-dev.2",
+  "version": "0.0.1-dev.0",
   "description": "Wasm Cennznut codec",
   "main": "libNode/cennznut.js",
   "browser": "libBrowser/cennznut.js",


### PR DESCRIPTION
The `rm` command syntax in `build.sh` was working locally but failing silently in CI
- Release 0.0.1-dev.0